### PR TITLE
Configurabilidad

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,5 +24,40 @@ Modifying .bashrc...
 user1@computer:~/dynamic-bash-prompt$
 ```
 
+## Configuration
+Some parameters can be configured before importing this script. If any variable
+is already defined when you import the script, the value will not be
+overwritten. See the script to learn how to redefine them.
+
+  1. `DYN_PROMPT_BRANCH_COLOR` is an array or color numbers for branch names. By
+     default, branch names are taken from git flow. Real, visual color might
+     change depending on terminal configuration.
+
+  2. `DYN_PROMPT_BRANCH_DEFAULT_COLOR` is the color number used when the branch
+     name does not match any of the predefined names in the previous array.
+
+  3. `DYN_PROMPT_BRANCH_STATUS` is an array of colors and symbols to indicate
+     the current status.
+
+  4. `DYN_PROMPT_BRANCH_SEPARATOR` is a string used as a separator between your
+     prompt and the branch indicator.
+
+  5. `DYN_PROMPT_BRANCH_BEGIN` and `DYN_PROMPT_BRANCH_BEGIN` are two characters
+     used to wrap the branch+status indicator, usually `[` and `]`, `(` and `)`
+     ...
+
+Probably you will need some experimentation with these variables to suite your
+taste. For example, you might prefer:
+
+~~~{.bash}
+    DYN_PROMPT_BRANCH_SEPARATOR=" | "
+    DYN_PROMPT_BRANCH_BEGIN=" "
+    DYN_PROMPT_BRANCH_END=" "
+~~~
+
+
 ## Author
-Imanol Barberia (*imanol.barberia@gmail.com*)
+
+  * Imanol Barberia (*imanol.barberia@gmail.com*)  Original author
+
+  * Francesc Rocher (*francesc.rocher@gmail.com*)  Added configurable values


### PR DESCRIPTION
Cambios incluidos en este PR:

- Se conserva el prompt originalmente definido (no intrusivo)
- La función  dyn_prompt_on  no tiene en cuenta si el prompt ya es dinámico, muestra más de una vez la rama y el estado
- Se han añadido algunas variables para la configuración del look del promp que pueden definirse antes de importar el script
- Se usan arrays para elegir los colores, lo que permite extender a nuevos patrones de nombres de ramas, más un color por defecto
- Se actualiza la documentación para el tema de la configuración